### PR TITLE
Fix problem with fresh installation

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # pytimber
 
-A Python wrapping of the CALS API.
+Python wrapping of CALS API.
 
 ## Installation
 

--- a/pytimber/__init__.py
+++ b/pytimber/__init__.py
@@ -1,4 +1,4 @@
-__version__ = "1.0.0"
+__version__ = "1.0.1"
 
 cmmnbuild_deps = [
     "accsoft-cals-extr-client"

--- a/pytimber/pytimber.py
+++ b/pytimber/pytimber.py
@@ -15,7 +15,7 @@ try:
     # do not exist, so fall back to locally bundled .jar file in this case.
     if not mgr.is_registered("pytimber"):
         print("WARNING: pytimber is not registered with cmmnbuild_dep_manager "
-              " so falling back to bundled jar. Things may not work as "
+              "so falling back to bundled jar. Things may not work as "
               "expected...")
         raise ImportError
 

--- a/pytimber/pytimber.py
+++ b/pytimber/pytimber.py
@@ -10,6 +10,15 @@ try:
     # Try to get a lit of .jars from cmmnbuild_dep_manager.
     import cmmnbuild_dep_manager
     mgr = cmmnbuild_dep_manager.Manager()
+
+    # During first installation with cmmnbuild_dep_manager some necessary jars
+    # do not exist, so fall back to locally bundled .jar file in this case.
+    if not mgr.is_registered("pytimber"):
+        print("WARNING: pytimber is not registered with cmmnbuild_dep_manager "
+              " so falling back to bundled jar. Things may not work as "
+              "expected...")
+        raise ImportError
+
     jarlist = mgr.jars()
 
     # Allows to use a local log4j.properties file
@@ -26,7 +35,7 @@ except ImportError:
     # Could not import cmmnbuild_dep_manager -- it is probably not
     # installed. Fall back to using the locally bundled .jar file.
     _moddir=os.path.dirname(__file__)
-    _jar=os.path.join(_moddir,'jars/accsoft-cals-extr-client-nodep.jar')
+    _jar=os.path.join(_moddir, 'jars', 'accsoft-cals-extr-client-nodep.jar')
 
 if not jpype.isJVMStarted():
     libjvm=jpype.getDefaultJVMPath()


### PR DESCRIPTION
A fix for a problem encountered with a fresh installation of PyTimber when cmmnbuild_dep_manager has no jars.