### PR TITLE
Fixed timestamp regression

### DIFF
--- a/README.md
+++ b/README.md
@@ -72,3 +72,7 @@ t1 = t2 - datetime.timedelta(hours=48)
 fills = ldb.getLHCFillsByTime(t1, t2, beam_modes="RAMP")
 print([f['fillNumber'] for f in fills])
 ```
+
+By default all times are returned as Unix timestamps. If you pass
+`unixtime=False` to `get()`, `getAligned()`, `getLHCFillData()` or
+`getLHCFillsByTime()` then `datetime` objects are returned instead.

--- a/pytimber/__init__.py
+++ b/pytimber/__init__.py
@@ -1,4 +1,4 @@
-__version__ = "2.1.0"
+__version__ = "2.1.1"
 
 cmmnbuild_deps = [
     "accsoft-cals-extr-client"


### PR DESCRIPTION
Fixes a regression fetching unix timestamps introduced in PR #9 and defaults the new functions to return unix timestamps.