### PR TITLE
Changed LHC fill beam modes to a list

### DIFF
--- a/pytimber/__init__.py
+++ b/pytimber/__init__.py
@@ -1,4 +1,4 @@
-__version__ = "2.1.1"
+__version__ = "2.1.2"
 
 cmmnbuild_deps = [
     "accsoft-cals-extr-client"

--- a/pytimber/pytimber.py
+++ b/pytimber/pytimber.py
@@ -324,12 +324,14 @@ class LoggingDB(object):
                 'fillNumber': data.getFillNumber(),
                 'startTime': self.fromTimestamp(data.getStartTime(), unixtime),
                 'endTime': self.fromTimestamp(data.getEndTime(), unixtime),
-                'beamModes': {mode.getBeamModeValue().toString(): {
+                'beamModes': [{
+                    'mode':
+                        mode.getBeamModeValue().toString(),
                     'startTime':
                         self.fromTimestamp(mode.getStartTime(), unixtime),
                     'endTime':
                         self.fromTimestamp(mode.getEndTime(), unixtime)
-                } for mode in data.getBeamModes()}
+                } for mode in data.getBeamModes()]
             }
 
     def getLHCFillsByTime(self, t1, t2, beam_modes=None, unixtime=True):


### PR DESCRIPTION
Previously it was a dict with the beam mode as the key, but this did
not support fills with multiple instances of beam modes. Now it is a
list with the beam modes in the order returned by CALS.