### PR TITLE
Require cmmnbuild_dep_manager

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # pytimber changelog
 
+## 07/2016 (T. Levens)
+
+  * Now requires cmmnbuild_dep_manager.
+
 ## 04/2016 (T. Levens)
 
   * Added functions to get LHC fill information.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,6 @@
 # pytimber changelog
 
-## 07/2016 (T. Levens)
+## 06/2016 (T. Levens)
 
   * Now requires cmmnbuild_dep_manager.
 

--- a/README.md
+++ b/README.md
@@ -12,18 +12,17 @@ Install a Python distribution (e.g. [Anaconda][]) and a recent Java version
 [anaconda]: https://www.continuum.io/downloads
 
 ```sh
-pip install git+https://gitlab.cern.ch/scripting-tools/cmmnbuild-dep-manager.git
-pip install git+https://github.com/rdemaria/pytimber.git
+pip install git+https://github.com/rdemaria/pytimber.git --process-dependency-links
 ```
 
-[cmmnbuild-dep-manager][] provides automatic resolution of
-Java dependencies for CERN packages. It is required to use pytimber with other
-CERN libraries, such as [PyJapc][].
+This will also install [cmmnbuild-dep-manager][] to provide automatic
+resolution of Java dependencies for CERN packages. It is required to use
+pytimber with other CERN libraries, such as [PyJapc][].
 
 [cmmnbuild-dep-manager]: https://gitlab.cern.ch/scripting-tools/cmmnbuild-dep-manager
 [pyjapc]: https://gitlab.cern.ch/scripting-tools/pyjapc
 
-### Notes
+### Installation notes
 
   * For Windows, [this][jpype-win] pre-compiled version of JPype seems to work
     best.

--- a/README.md
+++ b/README.md
@@ -1,14 +1,28 @@
 # pytimber
 
-Python wrapping of CALS API.
+Python wrapping of the [CERN Accelerator Logging Service][cals] (CALS) API.
+
+[cals]: https://wikis.cern.ch/display/CALS/CERN+Accelerator+Logging+Service
 
 ## Installation
 
-Install a Python distribution (e.g. Anaconda) and a recent Java version (1.8) then:
+Install a Python distribution (e.g. [Anaconda][]) and a recent Java version
+(1.8), then simply install pytimber using pip:
 
 ```sh
 pip install git+https://github.com/rdemaria/pytimber.git
 ```
+
+### Notes
+
+  * For Windows, [this][jpype-win] pre-compiled version of JPype seems to work
+    best.
+
+  * In order to use pytimber with other CERN packages that use JPype, see
+    the [section below](#Installation with cmmnbuild-dep-manager).
+
+[anaconda]: https://www.continuum.io/downloads
+[jpype-win]: http://www.lfd.uci.edu/~gohlke/pythonlibs/#jpype
 
 ## Usage
 
@@ -64,7 +78,7 @@ Find all fill number in the last 48 hours that contained a ramp:
 ```python
 t2 = datetime.datetime.now()
 t1 = t2 - datetime.timedelta(hours=48)
-fills = ldb.getLHCFillsByTime(t1, t2, beam_modes="RAMP")
+fills = ldb.getLHCFillsByTime(t1, t2, beam_modes='RAMP')
 print([f['fillNumber'] for f in fills])
 ```
 
@@ -73,6 +87,10 @@ By default all times are returned as Unix timestamps. If you pass
 `getLHCFillsByTime()` then `datetime` objects are returned instead.
 
 ## Usage with PageStore
+
+pytimber can be combined with [PageStore][] for local data storage.
+
+[pagestore]: https://github.com/rdemaria/pagestore
 
 Installation (assuming pytimber is already installed):
 
@@ -83,43 +101,43 @@ pip install git+https://github.com/rdemaria/pagestore.git
 Usage example:
 
 ```python
+import pytimber
 import pagestore
 
-mydb=pagestore.PageStore("mydata.db","./datadb")
+ldb = pytimber.LoggingDB()
+mydb = pagestore.PageStore('mydata.db', './datadb')
 
-t1=time.mktime(time.strptime('Fri Apr 25 00:00:00 2016'))
+t1 = time.mktime(time.strptime('Fri Apr 25 00:00:00 2016'))
 mydb.store(ldb.get('%RQTD%I_MEAS', t1, t1+60))
 mydb.store(ldb.get('%RQTD%I_MEAS', t1+60, t1+120))
 
-mydata=mydb.get('RPMBB.UA47.RQTD.A45B2:I_MEAS',t1+90,t1+110)
-data=ldb.get('RPMBB.UA47.RQTD.A45B2:I_MEAS',t1+90,t1+110)
+mydata = mydb.get('RPMBB.UA47.RQTD.A45B2:I_MEAS', t1+90, t1+110)
+data = ldb.get('RPMBB.UA47.RQTD.A45B2:I_MEAS', t1+90, t1+110)
 for k in data:
-  print(mydata[k][0]-data[k][0])
-  print(mydata[k][1]-data[k][1])
-
+  print(mydata[k][0] - data[k][0])
+  print(mydata[k][1] - data[k][1])
 ```
 
 ## Installation with cmmnbuild-dep-manager
 
-[cmmnbuild-dep-manager][cmmnbuild-dep-manager] provides automatic resolution of
+[cmmnbuild-dep-manager][] provides automatic resolution of
 Java dependencies for CERN packages. It is required to use pytimber with other
-CERN libraries, such as [PyJapc][pyjapc].
+CERN libraries, such as [PyJapc][].
 
 [cmmnbuild-dep-manager]: https://gitlab.cern.ch/scripting-tools/cmmnbuild-dep-manager
 [pyjapc]: https://gitlab.cern.ch/scripting-tools/pyjapc
 
-The installation must be done from a machine connected to the CERN network:
+pytimber is automatically registered with cmmnbuild-dep-manager during
+installation and the necessary jars are downloaded. For this to work, the
+installation must be done from a machine connected to the CERN network.
 
 ```sh
 pip install git+https://gitlab.cern.ch/scripting-tools/cmmnbuild-dep-manager.git
 pip install git+https://github.com/rdemaria/pytimber.git
 ```
 
-pytimber is automatically registered with cmmnbuild-dep-manager during
-installation and the necessary jars are downloaded.
-
 Note: if cmmnbuild-dep-manager is installed _after_ pytimber, it is necessary
-to manually register it and download the jars:
+to manually register pytimber and download the jars:
 
 ```python
 import cmmnbuild_dep_manager

--- a/README.md
+++ b/README.md
@@ -7,21 +7,27 @@ Python wrapping of the [CERN Accelerator Logging Service][cals] (CALS) API.
 ## Installation
 
 Install a Python distribution (e.g. [Anaconda][]) and a recent Java version
-(1.8), then simply install pytimber using pip:
+(1.8), then install pytimber using pip:
+
+[anaconda]: https://www.continuum.io/downloads
 
 ```sh
+pip install git+https://gitlab.cern.ch/scripting-tools/cmmnbuild-dep-manager.git
 pip install git+https://github.com/rdemaria/pytimber.git
 ```
+
+[cmmnbuild-dep-manager][] provides automatic resolution of
+Java dependencies for CERN packages. It is required to use pytimber with other
+CERN libraries, such as [PyJapc][].
+
+[cmmnbuild-dep-manager]: https://gitlab.cern.ch/scripting-tools/cmmnbuild-dep-manager
+[pyjapc]: https://gitlab.cern.ch/scripting-tools/pyjapc
 
 ### Notes
 
   * For Windows, [this][jpype-win] pre-compiled version of JPype seems to work
     best.
 
-  * In order to use pytimber with other CERN packages that use JPype, see
-    the [section below](#installation-with-cmmnbuild-dep-manager).
-
-[anaconda]: https://www.continuum.io/downloads
 [jpype-win]: http://www.lfd.uci.edu/~gohlke/pythonlibs/#jpype
 
 ## Usage
@@ -116,31 +122,4 @@ data = ldb.get('RPMBB.UA47.RQTD.A45B2:I_MEAS', t1+90, t1+110)
 for k in data:
   print(mydata[k][0] - data[k][0])
   print(mydata[k][1] - data[k][1])
-```
-
-## Installation with cmmnbuild-dep-manager
-
-[cmmnbuild-dep-manager][] provides automatic resolution of
-Java dependencies for CERN packages. It is required to use pytimber with other
-CERN libraries, such as [PyJapc][].
-
-[cmmnbuild-dep-manager]: https://gitlab.cern.ch/scripting-tools/cmmnbuild-dep-manager
-[pyjapc]: https://gitlab.cern.ch/scripting-tools/pyjapc
-
-pytimber is automatically registered with cmmnbuild-dep-manager during
-installation and the necessary jars are downloaded. For this to work, the
-installation must be done from a machine connected to the CERN network.
-
-```sh
-pip install git+https://gitlab.cern.ch/scripting-tools/cmmnbuild-dep-manager.git
-pip install git+https://github.com/rdemaria/pytimber.git
-```
-
-Note: if cmmnbuild-dep-manager is installed _after_ pytimber, it is necessary
-to manually register pytimber and download the jars:
-
-```python
-import cmmnbuild_dep_manager
-mgr = cmmnbuild_dep_manager.Manager()
-mgr.install('pytimber')
 ```

--- a/README.md
+++ b/README.md
@@ -19,7 +19,7 @@ pip install git+https://github.com/rdemaria/pytimber.git
     best.
 
   * In order to use pytimber with other CERN packages that use JPype, see
-    the [section below](#Installation with cmmnbuild-dep-manager).
+    the [section below](#installation-with-cmmnbuild-dep-manager).
 
 [anaconda]: https://www.continuum.io/downloads
 [jpype-win]: http://www.lfd.uci.edu/~gohlke/pythonlibs/#jpype

--- a/pytimber/__init__.py
+++ b/pytimber/__init__.py
@@ -8,6 +8,6 @@ from . import timberdata
 
 __version__ = "2.2.0"
 
-cmmnbuild_deps = (
+cmmnbuild_deps = [
     "accsoft-cals-extr-client"
-)
+]

--- a/pytimber/__init__.py
+++ b/pytimber/__init__.py
@@ -1,22 +1,13 @@
 # -*- coding: utf-8 -*-
 
+from .pytimber import LoggingDB
+from .dataquery import (DataQuery, parsedate, dumpdate,
+                        flattenoverlap, set_xaxis_date,
+                        set_xaxis_utctime, set_xlim_date, get_xlim_date)
+from . import timberdata
+
 __version__ = "2.2.0"
 
-cmmnbuild_deps = [
+cmmnbuild_deps = (
     "accsoft-cals-extr-client"
-]
-
-# When running setuptools without required dependencies installed
-# we need to be able to access __version__, so print a warning but
-# continue
-try:
-    from .pytimber import LoggingDB
-    from .dataquery import (DataQuery, parsedate, dumpdate,
-                            flattenoverlap, set_xaxis_date,
-                            set_xaxis_utctime, set_xlim_date, get_xlim_date)
-    from . import timberdata
-except ImportError:
-    import logging
-    logging.basicConfig()
-    log = logging.getLogger(__name__)
-    log.warning("required dependencies are not installed")
+)

--- a/pytimber/__init__.py
+++ b/pytimber/__init__.py
@@ -1,4 +1,6 @@
-__version__ = "2.1.10"
+# -*- coding: utf-8 -*-
+
+__version__ = "2.2.0"
 
 cmmnbuild_deps = [
     "accsoft-cals-extr-client"
@@ -9,9 +11,9 @@ cmmnbuild_deps = [
 # continue
 try:
     from .pytimber import LoggingDB
-    from .dataquery import DataQuery, parsedate, dumpdate, \
-                           flattenoverlap,set_xaxis_date, \
-                           set_xaxis_utctime, set_xlim_date, get_xlim_date
+    from .dataquery import (DataQuery, parsedate, dumpdate,
+                            flattenoverlap, set_xaxis_date,
+                            set_xaxis_utctime, set_xlim_date, get_xlim_date)
     from . import timberdata
 except ImportError:
     import logging

--- a/pytimber/pytimber.py
+++ b/pytimber/pytimber.py
@@ -41,6 +41,14 @@ import cmmnbuild_dep_manager
 from collections import namedtuple
 
 
+Stat = namedtuple(
+    'Stat',
+    ['MinTstamp', 'MaxTstamp', 'ValueCount',
+     'MinValue', 'MaxValue', 'AvgValue',
+     'StandardDeviationValue']
+)
+
+
 class LoggingDB(object):
     def __init__(self, appid='LHC_MD_ABP_ANALYSIS', clientid='BEAM PHYSICS',
                  source='all', loglevel=None):
@@ -272,13 +280,6 @@ class LoggingDB(object):
             return []
 
     def getStats(self, pattern_or_list, t1, t2, unixtime=True):
-        Stat = namedtuple(
-            'Stat',
-            ['MinTstamp', 'MaxTstamp', 'ValueCount',
-             'MinValue', 'MaxValue', 'AvgValue',
-             'StandardDeviationValue']
-        )
-
         ts1 = self.toTimestamp(t1)
         ts2 = self.toTimestamp(t2)
 

--- a/pytimber/pytimber.py
+++ b/pytimber/pytimber.py
@@ -1,98 +1,80 @@
+#!/usr/bin/env python
 # -*- coding: utf-8 -*-
+'''
+PyTimber -- A Python wrapping of CALS API
 
-# Authors:
-#   R. De Maria
-#   T. Levens
-#   C. Hernalsteens
-#   M. Betz
+Copyright (c) CERN 2015-2016
+
+Permission is hereby granted, free of charge, to any person obtaining a copy of
+this software and associated documentation files (the "Software"), to deal in
+the Software without restriction, including without limitation the rights to
+use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies
+of the Software, and to permit persons to whom the Software is furnished to do
+so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.
+
+Authors:
+    R. De Maria     <riccardo.de.maria@cern.ch>
+    T. Levens       <tom.levens@cern.ch>
+    C. Hernalsteens <cedric.hernalsteens@cern.ch>
+    M. Betz         <michael.betz@cern.ch>
+'''
 
 import os
-import glob
 import time
 import datetime
 import six
 import logging
-
 import jpype
 import numpy as np
-
-"""Latest version of the standalone jar is availale here:
-http://abwww.cern.ch/ap/dist/accsoft/cals/accsoft-cals-extr-client/PRO/build/dist/accsoft-cals-extr-client-nodep.jar
-"""
-
-logging.basicConfig()
-log = logging.getLogger(__name__)
-
-try:
-    # Try to get a lit of .jars from cmmnbuild_dep_manager.
-    import cmmnbuild_dep_manager
-    mgr = cmmnbuild_dep_manager.Manager()
-    logging.getLogger(
-        'cmmnbuild_dep_manager.cmmnbuild_dep_manager'
-    ).setLevel(logging.WARNING)
-
-    # During first installation with cmmnbuild_dep_manager some necessary jars
-    # do not exist, so fall back to locally bundled .jar file in this case.
-    if not mgr.is_registered('pytimber'):
-        log.warning('pytimber is not registered with cmmnbuild_dep_manager '
-                    'so falling back to bundled jar. Things may not work as '
-                    'expected...')
-        raise ImportError
-
-    _jar = mgr.class_path()
-except ImportError:
-    # Could not import cmmnbuild_dep_manager -- it is probably not
-    # installed. Fall back to using the locally bundled .jar file.
-    _moddir = os.path.dirname(__file__)
-    _jar = os.path.join(_moddir, 'jars', 'accsoft-cals-extr-client-nodep.jar')
-
-if not jpype.isJVMStarted():
-    libjvm = os.environ.get('JAVA_JVM_LIB')
-    if libjvm is None:
-      libjvm = jpype.getDefaultJVMPath()
-    jpype.startJVM(libjvm, '-Djava.class.path={0}'.format(_jar))
-else:
-    log.warning('JVM is already started')
-
-# Definitions of Java packages
-cern = jpype.JPackage('cern')
-org = jpype.JPackage('org')
-java = jpype.JPackage('java')
-ServiceBuilder = cern.accsoft.cals.extr.client.service.ServiceBuilder
-DataLocationPreferences = \
-        cern.accsoft.cals.extr.domain.core.datasource.DataLocationPreferences
-VariableDataType = \
-        cern.accsoft.cals.extr.domain.core.constants.VariableDataType
-Timestamp = java.sql.Timestamp
-null = org.apache.log4j.varia.NullAppender()
-org.apache.log4j.BasicConfigurator.configure(null)
-BeamModeValue = \
-    cern.accsoft.cals.extr.domain.core.constants.BeamModeValue
-
-source_dict = {
-    'mdb': DataLocationPreferences.MDB_PRO,
-    'ldb': DataLocationPreferences.LDB_PRO,
-    'all': DataLocationPreferences.MDB_AND_LDB_PRO
-}
-
-
-def test():
-    print('OK')
+import cmmnbuild_dep_manager
 
 
 class LoggingDB(object):
     def __init__(self, appid='LHC_MD_ABP_ANALYSIS', clientid='BEAM PHYSICS',
-                 source='all', silent=False, loglevel=None):
-        loc = source_dict[source]
-        self._builder = ServiceBuilder.getInstance(appid, clientid, loc)
-        self._md = self._builder.createMetaService()
-        self._ts = self._builder.createTimeseriesService()
-        self._FillService = FillService = self._builder.createLHCFillService()
-        self.tree = Hierarchy('root', None, None, self._md)
+                 source='all', loglevel=None):
+        # Configure logging
+        logging.basicConfig()
+        self._log = logging.getLogger(__name__)
         if loglevel is not None:
-            log.setLevel(loglevel)
+            self._log.setLevel(loglevel)
+
+        # Start JVM
+        mgr = cmmnbuild_dep_manager.Manager()
+        mgr.log.setLevel(logging.WARNING)
+        mgr.start_jpype_jvm()
+
+        # log4j config
+        null = jpype.JPackage('org').apache.log4j.varia.NullAppender()
+        jpype.JPackage('org').apache.log4j.BasicConfigurator.configure(null)
+
+        # Data source preferences
+        DataLocPrefs = (jpype.JPackage('cern').accsoft.cals.extr.domain
+                        .core.datasource.DataLocationPreferences)
+        loc = {'mdb': DataLocPrefs.MDB_PRO,
+               'ldb': DataLocPrefs.LDB_PRO,
+               'all': DataLocPrefs.MDB_AND_LDB_PRO}[source]
+
+        ServiceBuilder = (jpype.JPackage('cern').accsoft.cals.extr.client
+                          .service.ServiceBuilder)
+        builder = ServiceBuilder.getInstance(appid, clientid, loc)
+        self._md = builder.createMetaService()
+        self._ts = builder.createTimeseriesService()
+        self._FillService = FillService = builder.createLHCFillService()
+        self.tree = Hierarchy('root', None, None, self._md)
 
     def toTimestamp(self, t):
+        Timestamp = jpype.java.sql.Timestamp
         if isinstance(t, six.string_types):
             return Timestamp.valueOf(t)
         elif isinstance(t, datetime.datetime):
@@ -118,28 +100,33 @@ class LoggingDB(object):
                 return datetime.datetime.fromtimestamp(t)
 
     def toStringList(self, myArray):
-        myList = java.util.ArrayList()
+        myList = jpype.java.util.ArrayList()
         for s in myArray:
             myList.add(s)
         return myList
 
     def search(self, pattern):
         """Search for parameter names. Wildcard is '%'."""
+        VariableDataType = (jpype.JPackage('cern').accsoft.cals.extr.domain
+                            .core.constants.VariableDataType)
         types = VariableDataType.ALL
         v = self._md.getVariablesOfDataTypeWithNameLikePattern(pattern, types)
         return v.toString()[1:-1].split(', ')
 
     def getFundamentals(self, t1, t2, fundamental):
-        log.info('Querying fundamentals (pattern: {0}):'.format(fundamental))
+        self._log.info(
+            'Querying fundamentals (pattern: {0}):'.format(fundamental)
+        )
         fundamentals = self._md.getFundamentalsInTimeWindowWithNameLikePattern(
-                        t1, t2, fundamental)
+            t1, t2, fundamental
+        )
         if fundamentals is None:
-            log.info('No fundamental found in time window')
+            self._log.info('No fundamental found in time window')
         else:
             logfuns = []
             for f in fundamentals:
                 logfuns.append(f)
-            log.info('List of fundamentals found: {0}'.format(
+            self._log.info('List of fundamentals found: {0}'.format(
                 ', '.join(logfuns)))
         return fundamentals
 
@@ -147,13 +134,17 @@ class LoggingDB(object):
         """Get a list of variables based on a list of strings or a pattern.
         Wildcard for the pattern is '%'.
         """
+        VariableDataType = (jpype.JPackage('cern').accsoft.cals.extr.domain
+                            .core.constants.VariableDataType)
         if isinstance(pattern_or_list, six.string_types):
             types = VariableDataType.ALL
             variables = self._md.getVariablesOfDataTypeWithNameLikePattern(
-                    pattern_or_list, types)
+                pattern_or_list, types
+            )
         elif isinstance(pattern_or_list, (list, tuple)):
             variables = self._md.getVariablesWithNameInListofStrings(
-                    java.util.Arrays.asList(pattern_or_list))
+                jpype.java.util.Arrays.asList(pattern_or_list)
+            )
         else:
             variables = None
         return variables
@@ -164,19 +155,20 @@ class LoggingDB(object):
         for tt in dataset:
             ts = self.fromTimestamp(tt.getStamp(), unixtime)
             if datatype == 'MATRIXNUMERIC':
-                val = np.array(tt.getMatrixDoubleValues(),dtype=float)
+                val = np.array(tt.getMatrixDoubleValues(), dtype=float)
             elif datatype == 'VECTORNUMERIC':
-                val = np.array(tt.getDoubleValues(),dtype=float)
+                val = np.array(tt.getDoubleValues(), dtype=float)
             elif datatype == 'VECTORSTRING':
-                val = np.array(tt.getStringValues(),dtype='U')
+                val = np.array(tt.getStringValues(), dtype='U')
             elif datatype == 'NUMERIC':
                 val = tt.getDoubleValue()
             elif datatype == 'FUNDAMENTAL':
                 val = 1
             elif datatype == 'TEXTUAL':
-                val = unicode(tt.getVarcharValue())
+                val = six.u(tt.getVarcharValue())
             else:
-                log.warning('Unsupported datatype, returning the java object')
+                self._log.warning('Unsupported datatype, returning the '
+                                  'java object')
                 val = tt
             datas.append(val)
             tss.append(ts)
@@ -210,13 +202,13 @@ class LoggingDB(object):
             master_variable = variables.getVariable(master)
 
         if master_variable is None:
-            log.warning('Master variable not found.')
+            self._log.warning('Master variable not found.')
             return {}
 
         master_name = master_variable.toString()
 
         if len(variables) == 0:
-            log.warning('No variables found.')
+            self._log.warning('No variables found.')
             return {}
         else:
             logvars = []
@@ -226,17 +218,21 @@ class LoggingDB(object):
                 else:
                     logvars.append(v)
 
-            log.info('List of variables to be queried: {0}'.format(
-                ', '.join(logvars)))
+            self._log.info('List of variables to be queried: {0}'.format(
+                ', '.join(logvars)
+            ))
 
         # Acquire master dataset
         if fundamental is not None:
             master_ds = self._ts.getDataInTimeWindowFilteredByFundamentals(
-                    master_variable, ts1, ts2, fundamentals)
+                master_variable, ts1, ts2, fundamentals
+            )
         else:
-            master_ds = self._ts.getDataInTimeWindow(master_variable, ts1, ts2)
+            master_ds = self._ts.getDataInTimeWindow(
+                master_variable, ts1, ts2
+            )
 
-        log.info('Retrieved {0} values for {1} (master)'.format(
+        self._log.info('Retrieved {0} values for {1} (master)'.format(
             master_ds.size(), master_name))
 
         # Prepare master dataset for output
@@ -253,11 +249,13 @@ class LoggingDB(object):
             jvar = variables.getVariable(v)
             start_time = time.time()
             res = self._ts.getDataAlignedToTimestamps(jvar, master_ds)
-            log.info('Retrieved {0} values for {1}'.format(
-                res.size(), jvar.getVariableName()))
-            log.info('{0} seconds for aqn'.format(time.time()-start_time))
+            self._log.info('Retrieved {0} values for {1}'.format(
+                res.size(), jvar.getVariableName()
+            ))
+            self._log.info('{0} seconds for aqn'.format(time.time()-start_time))
             out[v] = self.processDataset(
-                       res, res.getVariableDataType().toString(), unixtime)[1]
+                res, res.getVariableDataType().toString(), unixtime
+            )[1]
         return out
 
     def searchFundamental(self, fundamental, t1, t2=None):
@@ -286,26 +284,26 @@ class LoggingDB(object):
         be explicitely provided.
         """
         ts1 = self.toTimestamp(t1)
-        if t2 not in ['last','next',None]:
-          ts2 = self.toTimestamp(t2)
+        if t2 not in ['last', 'next', None]:
+            ts2 = self.toTimestamp(t2)
         out = {}
 
         # Build variable list
         variables = self.getVariablesList(pattern_or_list)
         if len(variables) == 0:
-            log.warning('No variables found.')
+            self._log.warning('No variables found.')
             return {}
         else:
             logvars = []
             for v in variables:
                 logvars.append(v)
-            log.info('List of variables to be queried: {0}'.format(
+            self._log.info('List of variables to be queried: {0}'.format(
                 ', '.join(logvars)))
 
         # Fundamentals
         if fundamental is not None and ts2 is None:
-            log.warning('Unsupported: if filtering by fundamentals'
-                        'you must provide a correct time window')
+            self._log.warning('Unsupported: if filtering by fundamentals '
+                              'you must provide a correct time window')
             return {}
         if fundamental is not None:
             fundamentals = self.getFundamentals(ts1, ts2, fundamental)
@@ -315,33 +313,41 @@ class LoggingDB(object):
         # Acquire
         for v in variables:
             jvar = variables.getVariable(v)
-            if t2 is None or t2=='last':
-                res = \
-                  [self._ts.getLastDataPriorToTimestampWithinDefaultInterval(
-                    jvar, ts1)]
+            if t2 is None or t2 == 'last':
+                res = [
+                    self._ts.getLastDataPriorToTimestampWithinDefaultInterval(
+                        jvar, ts1
+                    )
+                ]
                 datatype = res[0].getVariableDataType().toString()
-                log.info('Retrieved {0} values for {1}'.format(
-                           1, jvar.getVariableName()))
-            elif t2=='next':
-                res = \
-                  [self._ts.getNextDataAfterTimestampWithinDefaultInterval(
-                    jvar, ts1)]
+                self._log.info('Retrieved {0} values for {1}'.format(
+                    1, jvar.getVariableName()
+                ))
+            elif t2 == 'next':
+                res = [
+                    self._ts.getNextDataAfterTimestampWithinDefaultInterval(
+                        jvar, ts1
+                    )
+                ]
                 if res[0] is None:
-                  res=[]
-                  datatype=None
+                    res = []
+                    datatype = None
                 else:
-                  datatype = res[0].getVariableDataType().toString()
-                  log.info('Retrieved {0} values for {1}'.format(
-                           1, jvar.getVariableName()))
+                    datatype = res[0].getVariableDataType().toString()
+                    self._log.info('Retrieved {0} values for {1}'.format(
+                        1, jvar.getVariableName()
+                    ))
             else:
                 if fundamental is not None:
                     res = self._ts.getDataInTimeWindowFilteredByFundamentals(
-                            jvar, ts1, ts2, fundamentals)
+                        jvar, ts1, ts2, fundamentals
+                    )
                 else:
                     res = self._ts.getDataInTimeWindow(jvar, ts1, ts2)
                 datatype = res.getVariableDataType().toString()
-                log.info('Retrieved {0} values for {1}'.format(
-                    res.size(), jvar.getVariableName()))
+                self._log.info('Retrieved {0} values for {1}'.format(
+                    res.size(), jvar.getVariableName()
+                ))
             out[v] = self.processDataset(res, datatype, unixtime)
         return out
 
@@ -380,6 +386,9 @@ class LoggingDB(object):
         """
         ts1 = self.toTimestamp(t1)
         ts2 = self.toTimestamp(t2)
+
+        BeamModeValue = (jpype.JPackage('cern').accsoft.cals.extr.domain
+                         .core.constants.BeamModeValue)
 
         if beam_modes is None:
             fills = self._FillService.getLHCFillsAndBeamModesInTimeWindow(
@@ -467,9 +476,12 @@ class Hierarchy(object):
             return '<{0}: {1}>'.format(name, desc)
 
     def get_vars(self):
+        VariableDataType = (jpype.JPackage('cern').accsoft.cals.extr.domain
+                            .core.constants.VariableDataType)
         if self.obj is not None:
             vvv = self.varsrc.getVariablesOfDataTypeAttachedToHierarchy(
-                    self.obj, VariableDataType.ALL)
+                self.obj, VariableDataType.ALL
+            )
             return vvv.toString()[1:-1].split(', ')
         else:
             return []

--- a/setup.py
+++ b/setup.py
@@ -8,15 +8,13 @@ import pytimber
 
 
 class install(_install):
+    '''Install and perform the jar resolution'''
     def run(self):
-        try:
-            import cmmnbuild_dep_manager
-            mgr = cmmnbuild_dep_manager.Manager()
-            mgr.install('pytimber')
-            print('registered pytimber with cmmnbuild_dep_manager')
-        except ImportError:
-            pass
-        _install.run(self)
+        import cmmnbuild_dep_manager
+        mgr = cmmnbuild_dep_manager.Manager()
+        mgr.install('pytimber')
+        print('registered pytimber with cmmnbuild_dep_manager')
+        super().run(self)
 
 setuptools.setup(
     name='pytimber',
@@ -26,9 +24,19 @@ setuptools.setup(
     author_email='riccardo.de.maria@cern.ch',
     url='https://github.com/rdemaria/pytimber',
     packages=['pytimber'],
-    package_dir={'pytimber': 'pytimber'},
-    install_requires=['JPype1>=0.6.0'],
-    cmdclass={'install': install},
-    package_data={'pytimber': ['jars/*']},
+    package_dir={
+        'pytimber': 'pytimber'
+    },
+    setup_requires=[
+        'cmmnbuild-dep-manager'
+    ],
+    install_requires=[
+        'numpy',
+        'JPype1',
+        'cmmnbuild-dep-manager'
+    ],
+    cmdclass={
+        'install': install
+    },
     zip_safe=False
 )

--- a/setup.py
+++ b/setup.py
@@ -37,11 +37,11 @@ setuptools.setup(
         'pytimber': 'pytimber'
     },
     setup_requires=[
-        'cmmnbuild-dep-manager>=1.2.9'
+        'cmmnbuild_dep_manager>=1.2.9'
     ],
     install_requires=[
         'JPype1>=0.6.1',
-        'cmmnbuild-dep-manager>=1.2.9'
+        'cmmnbuild_dep_manager>=1.2.9'
     ],
     cmdclass={
         'install': install

--- a/setup.py
+++ b/setup.py
@@ -24,7 +24,7 @@ class install(_install):
         mgr = cmmnbuild_dep_manager.Manager()
         mgr.install('pytimber')
         print('registered pytimber with cmmnbuild_dep_manager')
-        super(install, self).run()
+        _install.run(self)
 
 setuptools.setup(
     name='pytimber',

--- a/setup.py
+++ b/setup.py
@@ -38,12 +38,12 @@ setuptools.setup(
         'pytimber': 'pytimber'
     },
     setup_requires=[
-        'cmmnbuild-dep-manager'
+        'cmmnbuild-dep-manager>=1.2.9'
     ],
     install_requires=[
         'numpy',
-        'JPype1',
-        'cmmnbuild-dep-manager'
+        'JPype1>=0.6.1',
+        'cmmnbuild-dep-manager>=1.2.9'
     ],
     cmdclass={
         'install': install

--- a/setup.py
+++ b/setup.py
@@ -1,10 +1,20 @@
 #!/usr/bin/env python
 # -*- coding: utf-8 -*-
 
+import os
+import ast
 import setuptools
 from setuptools.command.install import install as _install
 
-import pytimber
+
+def get_version_from_init():
+    init_file = os.path.join(
+        os.path.dirname(__file__), 'pytimber', '__init__.py'
+    )
+    with open(init_file, 'r') as file:
+        for line in file:
+            if line.startswith('__version__'):
+                return ast.literal_eval(line.split('=', 1)[1].strip())
 
 
 class install(_install):
@@ -14,11 +24,11 @@ class install(_install):
         mgr = cmmnbuild_dep_manager.Manager()
         mgr.install('pytimber')
         print('registered pytimber with cmmnbuild_dep_manager')
-        super().run(self)
+        super().run()
 
 setuptools.setup(
     name='pytimber',
-    version=pytimber.__version__,
+    version=get_version_from_init(),
     description='A Python wrapping of CALS API',
     author='Riccardo De Maria',
     author_email='riccardo.de.maria@cern.ch',

--- a/setup.py
+++ b/setup.py
@@ -24,7 +24,7 @@ class install(_install):
         mgr = cmmnbuild_dep_manager.Manager()
         mgr.install('pytimber')
         print('registered pytimber with cmmnbuild_dep_manager')
-        super().run()
+        super(install, self).run()
 
 setuptools.setup(
     name='pytimber',

--- a/setup.py
+++ b/setup.py
@@ -6,7 +6,6 @@ import ast
 import setuptools
 from setuptools.command.install import install as _install
 
-
 def get_version_from_init():
     init_file = os.path.join(
         os.path.dirname(__file__), 'pytimber', '__init__.py'
@@ -38,11 +37,14 @@ setuptools.setup(
         'pytimber': 'pytimber'
     },
     setup_requires=[
-        'cmmnbuild-dep-manager>=1.2.9'
+        'cmmnbuild_dep_manager>=1.2.9'
     ],
     install_requires=[
         'JPype1>=0.6.1',
-        'cmmnbuild-dep-manager>=1.2.9'
+        'cmmnbuild_dep_manager>=1.2.9'
+    ],
+    dependency_links=[
+        'git+https://gitlab.cern.ch/bi/cmmnbuild-dep-manager.git#egg=cmmnbuild_dep_manager'
     ],
     cmdclass={
         'install': install

--- a/setup.py
+++ b/setup.py
@@ -43,9 +43,6 @@ setuptools.setup(
         'JPype1>=0.6.1',
         'cmmnbuild_dep_manager>=1.2.9'
     ],
-    dependency_links=[
-        'git+https://gitlab.cern.ch/bi/cmmnbuild-dep-manager.git#egg=cmmnbuild_dep_manager'
-    ],
     cmdclass={
         'install': install
     },

--- a/setup.py
+++ b/setup.py
@@ -37,11 +37,11 @@ setuptools.setup(
         'pytimber': 'pytimber'
     },
     setup_requires=[
-        'cern-cmmnbuild-dep-manager>=1.2.9'
+        'cmmnbuild-dep-manager>=1.2.9'
     ],
     install_requires=[
         'JPype1>=0.6.1',
-        'cern-cmmnbuild-dep-manager>=1.2.9'
+        'cmmnbuild-dep-manager>=1.2.9'
     ],
     cmdclass={
         'install': install

--- a/setup.py
+++ b/setup.py
@@ -41,7 +41,6 @@ setuptools.setup(
         'cmmnbuild-dep-manager>=1.2.9'
     ],
     install_requires=[
-        'numpy',
         'JPype1>=0.6.1',
         'cmmnbuild-dep-manager>=1.2.9'
     ],

--- a/tests/test_fundamentals.py
+++ b/tests/test_fundamentals.py
@@ -9,4 +9,4 @@ log.get('CPS.TGM:USER%', now - timedelta(minutes = 10), now,
         fundamental=fundamental)
 
 
-print(log.searchFundamental('%'),now - timedelta(minutes = 10))
+print(log.searchFundamental('%', now - timedelta(minutes = 10)))


### PR DESCRIPTION
New version which requires cmmnbuild_dep_manager, which removes some duplicate code and the local copy of the jars. 

The initialisation of the JVM has been moved to the `LoggingDB.__init__()` function to allow installation without the local jars.