### PR TITLE
Added cmmnbuild-dep-manager installation

### DIFF
--- a/pytimber/__init__.py
+++ b/pytimber/__init__.py
@@ -6,7 +6,7 @@ from .dataquery import (DataQuery, parsedate, dumpdate,
                         set_xaxis_utctime, set_xlim_date, get_xlim_date)
 from . import timberdata
 
-__version__ = "2.2.1"
+__version__ = "2.2.2"
 
 cmmnbuild_deps = [
     "accsoft-cals-extr-client"

--- a/pytimber/pytimber.py
+++ b/pytimber/pytimber.py
@@ -60,6 +60,8 @@ class LoggingDB(object):
 
         # Start JVM
         mgr = cmmnbuild_dep_manager.Manager()
+        if not mgr.is_registered('pytimber'):
+            mgr.install('pytimber')
         mgr.log.setLevel(logging.WARNING)
         mgr.start_jpype_jvm()
 

--- a/setup.py
+++ b/setup.py
@@ -43,11 +43,20 @@ def cmmnbuild_version():
 # Custom install function
 class install(_install):
     '''Install and perform the jar resolution'''
+    user_options = _install.user_options + [
+        ('no-jars', None, 'do not register with cmmnbuild_dep_manager')
+    ]
+
+    def initialize_options(self):
+        self.no_jars = False
+        _install.initialize_options(self)
+
     def run(self):
-        import cmmnbuild_dep_manager
-        mgr = cmmnbuild_dep_manager.Manager()
-        mgr.install('pytimber')
-        print('registered pytimber with cmmnbuild_dep_manager')
+        if not self.no_jars:
+            import cmmnbuild_dep_manager
+            mgr = cmmnbuild_dep_manager.Manager()
+            mgr.install('pytimber')
+            print('registered pytimber with cmmnbuild_dep_manager')
         _install.run(self)
 
 

--- a/setup.py
+++ b/setup.py
@@ -71,7 +71,7 @@ setuptools.setup(
         'cmmnbuild_dep_manager>=1.2.9'
     ],
     dependency_links=[
-        cmmnbuild_url + 'repository/archive.zip?ref={0}#egg=cmmnbuild_dep_manager-{0}'.format(cmmnbuild_version())
+        cmmnbuild_url + 'repository/archive.zip?ref=master#egg=cmmnbuild_dep_manager-' + cmmnbuild_version()
     ],
     cmdclass={
         'install': install


### PR DESCRIPTION
Adds a step to install pytimber with cmmnbuild-dep-manager if it is not already registered.

This is a preparation for the next version of cmmnbuild-dep-manager which will support downloading the jars to a user's home directory (but is still compatible with the current version).

Hopefully this will make installation on SWAN simpler.