### PR TITLE
Add log4j and other requirements to cmmnbuild_deps

### DIFF
--- a/pytimber/__init__.py
+++ b/pytimber/__init__.py
@@ -6,8 +6,12 @@ from .dataquery import (DataQuery, parsedate, dumpdate,
                         set_xaxis_utctime, set_xlim_date, get_xlim_date)
 from . import timberdata
 
-__version__ = "2.2.3"
+__version__ = "2.2.4"
 
 cmmnbuild_deps = [
-    "accsoft-cals-extr-client"
+    "accsoft-cals-extr-client",
+    "accsoft-cals-extr-domain",
+    "slf4j-log4j12",
+    "slf4j-api",
+    "log4j"
 ]


### PR DESCRIPTION
Something changed in CO's repositories which means some required jars (`log4j`,  `slf4j-log4j12`) were not being downloaded any more. This PR adds these to the `cmmnbuild_deps`. I also added `accsoft-cals-extr-domain` which we use directly in PyTimber for safety.