### PR TITLE
very small (but effective) performance improvement for VectorNumeric values

### DIFF
--- a/pytimber/__init__.py
+++ b/pytimber/__init__.py
@@ -6,7 +6,7 @@ from .dataquery import (DataQuery, parsedate, dumpdate,
                         set_xaxis_utctime, set_xlim_date, get_xlim_date)
 from . import timberdata
 
-__version__ = "2.2.5"
+__version__ = "2.2.6"
 
 cmmnbuild_deps = [
     "accsoft-cals-extr-client",

--- a/pytimber/pytimber.py
+++ b/pytimber/pytimber.py
@@ -168,7 +168,7 @@ class LoggingDB(object):
             if datatype == 'MATRIXNUMERIC':
                 val = np.array(tt.getMatrixDoubleValues(), dtype=float)
             elif datatype == 'VECTORNUMERIC':
-                val = np.array(tt.getDoubleValues(), dtype=float)
+                val = np.array(tt.getDoubleValues()[:], dtype=float)
             elif datatype == 'VECTORSTRING':
                 val = np.array(tt.getStringValues(), dtype='U')
             elif datatype == 'NUMERIC':


### PR DESCRIPTION
Hi Riccardo,

Slowly switching over from Matlab, I was wondering why querying vectornumeric values (e.g. LHC bbb data) was significantly slower than with my Matlab Timber bridge. I found that most of the time is spent converting the jpype arrays in processDataset(). After applying slice operator as suggested in https://github.com/originell/jpype/issues/71, I get a speedup of a factor of ~20 (see below).

Cheers,
Michi


Before:
```
cProfile.run("logging.query('LHC.BQM.B1:BUNCH_INTENSITIES')");
         268617360 function calls (268613761 primitive calls) in 111.036 seconds

   Ordered by: standard name
...
    10755    0.005    0.000    0.005    0.000 _jarray.py:108(__init__)
    10755    0.001    0.000    0.001    0.000 _jarray.py:112(__iter__)
 38341575   28.759    0.000   94.865    0.000 _jarray.py:115(__next__)
     3585    0.002    0.000    0.002    0.000 _jarray.py:140(_getClassFor)
     3585    0.001    0.000    0.001    0.000 _jarray.py:42(__init__)
 38352330    8.137    0.000   25.949    0.000 _jarray.py:48(__len__)
    10755    0.008    0.000    0.013    0.000 _jarray.py:51(__iter__)
 38330820   14.365    0.000   28.808    0.000 _jarray.py:54(__getitem__)
     3585    0.005    0.000    0.007    0.000 _jarray.py:85(_jarrayInit)
        1    0.000    0.000    0.000    0.000 _jclass.py:165(<lambda>)
     3585    0.003    0.000    0.013    0.000 _jclass.py:171(<lambda>)
     7195    0.008    0.000    0.014    0.000 _jclass.py:60(_getClassFor)
     7188    0.013    0.000    0.014    0.000 _jclass.py:78(_javaInit)
61038/57453    0.048    0.000    0.068    0.000 _jclass.py:89(_javaGetAttr)
...
        1    5.147    5.147  111.031  111.031 pytimber.py:343(get)
```

After:
```
cProfile.run("logging.query('LHC.BQM.B1:BUNCH_INTENSITIES')");
         233505 function calls (229906 primitive calls) in 5.230 seconds

   Ordered by: standard name

   ncalls  tottime  percall  cumtime  percall filename:lineno(function)
     3585    0.001    0.000    0.001    0.000 _jarray.py:140(_getClassFor)
     3585    0.001    0.000    0.001    0.000 _jarray.py:42(__init__)
     3585    0.001    0.000    0.004    0.000 _jarray.py:48(__len__)
     3585    0.004    0.000    0.031    0.000 _jarray.py:54(__getitem__)
     3585    0.002    0.000    0.019    0.000 _jarray.py:75(__getslice__)
     3585    0.003    0.000    0.005    0.000 _jarray.py:85(_jarrayInit)
        1    0.000    0.000    0.000    0.000 _jclass.py:165(<lambda>)
     3585    0.002    0.000    0.010    0.000 _jclass.py:171(<lambda>)
     7195    0.005    0.000    0.008    0.000 _jclass.py:60(_getClassFor)
     7188    0.009    0.000    0.010    0.000 _jclass.py:78(_javaInit)
61038/57453    0.037    0.000    0.051    0.000 _jclass.py:89(_javaGetAttr)
...
        1    4.775    4.775    5.224    5.224 pytimber.py:343(get)
```

The latter is par with my Matlab code:
```
>> tic;bunchIntB1_bqm_raw = dataMiner.fetchDataSetTable('LHC.BQM.B1:BUNCH_INTENSITIES');toc;
Elapsed time is 5.156940 seconds.
```