### PR TITLE
fix dumpdate and dumpdateutc

### DIFF
--- a/pytimber/localdate.py
+++ b/pytimber/localdate.py
@@ -18,6 +18,8 @@ myfmt={'myf': '%Y-%m-%d--%H-%M-%S--%z',
        'cernlogdb' : '%Y%m%d%H%M%SCET',
        }
 
+# predefined time zones
+utc = pytz.timezone('UTC')
 
 def parsedate_myl(s):
   """Read a string in the '2010-06-10 00:00:00.123 TZ?' format and return
@@ -50,28 +52,45 @@ def parsedate(t):
   except ValueError:
     return parsedate_myl(t)
 
-def dumpdate(t,fmt='%Y-%m-%d %H:%M:%S.SSS',zone=myzones['cern']):
+def dumpdate(t=None,fmt='%Y-%m-%d %H:%M:%S.SSS',zone='cern'):
   """
   converts unix time [float] to time in time zone *zone* [string].
-  If zone = None local time is used.
+
+  Paramters:
+  ----------
+  t : unix time [s], if t = None the time now is used
+  fmt : = format string for output
+  zone : time zone, either predefined (bnl,cern,fnal,lbl and z for 
+         utc time) or datetime timezones (e.g. 'Europe/Zurich' for 
+         cern).
+         If zone = None local time is used
   """
+  if t is None:
+    t=time.time()
   ti = int(t)
   tf = t-ti
   if zone is None:
     s = time.strftime(fmt,time.localtime(t))
   else:
-    utc = pytz.timezone('UTC')
     utc_dt = datetime.utcfromtimestamp(t)
     utc_dt = utc_dt.replace(tzinfo = utc)
-    tz = pytz.timezone(zone)
+    tz = pytz.timezone(myzones.get(zone,zone))
     tz_dt = utc_dt.astimezone(tz)
     s = tz_dt.strftime(fmt)
   if 'SSS' in s:
     s=s.replace('SSS','%03d'%(tf*1000))
   return s
 
-def dumpdateutc(t,fmt='%Y-%m-%d %H:%M:%S.SSS'):
-  """converts unix time [float] to utc time [string]"""
+def dumpdateutc(t=None,fmt='%Y-%m-%d %H:%M:%S.SSS'):
+  """
+  converts unix time [float] to utc time [string]
+  Parameters:
+  -----------
+  t : unix time [s], if t = None the time now is used
+  fmt : = format string for output
+  """
+  if t is None:
+    t=time.time()
   ti=int(t)
   tf=t-ti
   utc_dt = datetime.utcfromtimestamp(t)

--- a/pytimber/localdate.py
+++ b/pytimber/localdate.py
@@ -50,11 +50,22 @@ def parsedate(t):
   except ValueError:
     return parsedate_myl(t)
 
-def dumpdate(t,fmt='%Y-%m-%d %H:%M:%S.SSS'):
-  """converts unix time to locale time"""
-  ti=int(t)
-  tf=t-ti
-  s=time.strftime(fmt,time.localtime(t))
+def dumpdate(t,fmt='%Y-%m-%d %H:%M:%S.SSS',zone=myzones['cern']):
+  """
+  converts unix time [float] to time in time zone *zone* [string].
+  If zone = None local time is used.
+  """
+  ti = int(t)
+  tf = t-ti
+  if zone is None:
+    s = time.strftime(fmt,time.localtime(t))
+  else:
+    utc = pytz.timezone('UTC')
+    utc_dt = datetime.utcfromtimestamp(t)
+    utc_dt = utc_dt.replace(tzinfo = utc)
+    tz = pytz.timezone(zone)
+    tz_dt = utc_dt.astimezone(tz)
+    s = tz_dt.strftime(fmt)
   if 'SSS' in s:
     s=s.replace('SSS','%03d'%(tf*1000))
   return s
@@ -63,14 +74,10 @@ def dumpdateutc(t,fmt='%Y-%m-%d %H:%M:%S.SSS'):
   """converts unix time [float] to utc time [string]"""
   ti=int(t)
   tf=t-ti
-  geneve = pytz.timezone('Europe/Berlin')
-  utc=pytz.utc
-  gen_dt=geneve.localize(datetime.datetime.fromtimestamp(t),is_dst=True)#take daylight saving time into account
-  utc_dt=gen_dt.astimezone(utc)
+  utc_dt = datetime.utcfromtimestamp(t)
   s=utc_dt.strftime(fmt)
   if 'SSS' in s:
-#    s=s.replace('SSS','%03d'%(tf*1000))
-    s=s.replace('.SSS','')
+    s=s.replace('SSS','%03d'%(tf*1000))
   return s
 
 


### PR DESCRIPTION
**Bug in `dumpdate` and `dumpdateutc` if not in Geneva time zone:**
- `dumpdate` and `dumpdateutc` returned the wrong time for the following example if you are not in the 'Europe/Zurich' timezone. For 'America/Chicago' one e.g. gets:
```
t=1471994443572646050*1.e-9
dumpdate(t) = '2016-08-23 18:20:43.000'
dumpdateutc(t) = '2016-08-23 16:20:43.000'
```
- for dumpdateutc I think it is better to use `datetime.utcfromtimestamp`
- for dumpdate I would go over the utc time which is a solid conversion
- `datetime.datetime` should also be replaced by `datetime` as it is imported as
`from datetime import datetime`

These two functions are also never used. I would suggest to maybe just remove them. If we take the version I proposed, please also test them before merging as I am not sure what exactly they were intended to do.

