### PR TITLE
Add back get_vars() to Hierarchy

### DIFF
--- a/README.md
+++ b/README.md
@@ -65,7 +65,7 @@ Explore variable hierarchies:
 ```python
 ldb.tree
 print(dir(ldb.tree))
-print(ldb.tree.LHC.Collimators.BPM.bpmColl._get_vars())
+print(ldb.tree.LHC.Collimators.BPM.bpmColl.get_vars())
 ```
 
 Get data for a particular LHC fill:

--- a/pytimber/pytimber.py
+++ b/pytimber/pytimber.py
@@ -601,3 +601,6 @@ class Hierarchy(object):
             return vvv.toString()[1:-1].split(', ')
         else:
             return []
+
+    def get_vars(self):
+        return self._get_vars()


### PR DESCRIPTION
This adds back a get_vars() method to the Hierarchy class which was removed in 3f5d98e.