### PR TITLE
added warning if NaN returned from getscaled

### DIFF
--- a/pytimber/pytimber.py
+++ b/pytimber/pytimber.py
@@ -533,6 +533,8 @@ class LoggingDB(object):
                 res.size(), jvar.getVariableName()
             ))
             out[v] = self.processDataset(res, datatype, unixtime)
+            if np.isnan(out[v][1]).any():
+                self._log.warning('Variable {} contains NaN values'.format(v))
         return out
 
     def getLHCFillData(self, fill_number=None, unixtime=True):


### PR DESCRIPTION
This check imitates Timber interface warning when scaling is done and no data is found in an interval