### PR TITLE
improve performance of processDataset()

### DIFF
--- a/pytimber/__init__.py
+++ b/pytimber/__init__.py
@@ -10,7 +10,7 @@ from . import timberdata
 
 from .pagestore import PageStore
 
-__version__ = "2.5.2"
+__version__ = "2.6.0"
 
 __cmmnbuild_deps__ = [
     "accsoft-cals-extr-client",

--- a/pytimber/__init__.py
+++ b/pytimber/__init__.py
@@ -10,11 +10,12 @@ from . import timberdata
 
 from .pagestore import PageStore
 
-__version__ = "2.5.1"
+__version__ = "2.5.2"
 
 __cmmnbuild_deps__ = [
     "accsoft-cals-extr-client",
     "accsoft-cals-extr-domain",
+    "lhc-commons-cals-utils",
     "slf4j-log4j12",
     "slf4j-api",
     "log4j"

--- a/pytimber/pytimber.py
+++ b/pytimber/pytimber.py
@@ -37,16 +37,16 @@ import time
 import datetime
 import six
 import logging
+
 try:
-  import jpype
-  import cmmnbuild_dep_manager
+    import jpype
+    import cmmnbuild_dep_manager
 except ImportError:
-  print("""ERROR: module jpype and cmmnbuild_dep_manager not found!
+    print("""ERROR: module jpype and cmmnbuild_dep_manager not found!
         Exporting data from the logging database will not be
         available!""")
 import numpy as np
 from collections import namedtuple
-
 
 Stat = namedtuple(
     'Stat',
@@ -54,7 +54,6 @@ Stat = namedtuple(
      'MinValue', 'MaxValue', 'AvgValue',
      'StandardDeviationValue']
 )
-
 
 if six.PY3:
     long = int
@@ -65,9 +64,10 @@ if six.PY3:
 
 class LoggingDB(object):
     try:
-      _jpype=jpype
+        _jpype = jpype
     except NameError:
-      print('ERROR: jpype is note defined!')
+        print('ERROR: jpype is note defined!')
+
     def __init__(self, appid='LHC_MD_ABP_ANALYSIS', clientid='BEAM PHYSICS',
                  source='all', loglevel=None):
         # Configure logging
@@ -94,7 +94,7 @@ class LoggingDB(object):
         ServiceBuilder = (jpype.JPackage('cern').accsoft.cals.extr.client
                           .service.ServiceBuilder)
         builder = ServiceBuilder.getInstance(appid, clientid, loc)
-        self._builder=builder
+        self._builder = builder
         self._md = builder.createMetaService()
         self._ts = builder.createTimeseriesService()
         self._FillService = FillService = builder.createLHCFillService()
@@ -108,12 +108,12 @@ class LoggingDB(object):
             return Timestamp.valueOf(t.strftime('%Y-%m-%d %H:%M:%S.%f'))
         elif t is None:
             return None
-        elif isinstance(t,Timestamp):
+        elif isinstance(t, Timestamp):
             return t
         else:
-            ts = Timestamp(long(t*1000))
+            ts = Timestamp(long(t * 1000))
             sec = int(t)
-            nanos = int((t-sec)*1e9)
+            nanos = int((t - sec) * 1e9)
             ts.setNanos(nanos)
             return ts
 
@@ -134,32 +134,35 @@ class LoggingDB(object):
         return myList
 
     def toTimescale(self, timescale_list):
-      Timescale = jpype.JPackage('cern').accsoft.cals.extr.domain.core.constants.TimescalingProperties
-      try:
-        timescale_str='_'.join(timescale_list)
-        return Timescale.valueOf(timescale_str)
-      except Exception as e:
-        self._log.warning('exception in timescale:{}'.format(e))
+        Timescale = jpype.JPackage('cern').accsoft.cals.extr.domain.core.constants.TimescalingProperties
+        try:
+            timescale_str = '_'.join(timescale_list)
+            return Timescale.valueOf(timescale_str)
+        except Exception as e:
+            self._log.warning('exception in timescale:{}'.format(e))
 
-    def getVariables(self,pattern):
+    def getVariables(self, pattern):
         """Get Variable from pattern. Wildcard is '%'."""
         VariableDataType = (jpype.JPackage('cern').accsoft.cals.extr.domain
                             .core.constants.VariableDataType)
         types = VariableDataType.ALL
-        v=self._md.getVariablesOfDataTypeWithNameLikePattern(pattern, types)
+        v = self._md.getVariablesOfDataTypeWithNameLikePattern(pattern, types)
         return list(v.getVariables())
+
     def search(self, pattern):
         """Search for parameter names. Wildcard is '%'."""
         return [vv.getVariableName() for vv in self.getVariables(pattern)]
 
-    def getDescription(self,pattern):
+    def getDescription(self, pattern):
         """Get Variable Description from pattern. Wildcard is '%'."""
-        return dict([(vv.getVariableName(),vv.getDescription())
-                                         for vv in self.getVariables(pattern)])
-    def getUnit(self,pattern):
+        return dict([(vv.getVariableName(), vv.getDescription())
+                     for vv in self.getVariables(pattern)])
+
+    def getUnit(self, pattern):
         """Get Variable Unit from pattern. Wildcard is '%'."""
-        return dict([(vv.getVariableName(),vv.getUnit())
-                                         for vv in self.getVariables(pattern)])
+        return dict([(vv.getVariableName(), vv.getUnit())
+                     for vv in self.getVariables(pattern)])
+
     def getFundamentals(self, t1, t2, fundamental):
         self._log.info(
             'Querying fundamentals (pattern: {0}):'.format(fundamental)
@@ -200,52 +203,61 @@ class LoggingDB(object):
         spi = (jpype.JPackage('cern').accsoft.cals.extr.domain.core
                .timeseriesdata.spi)
 
-        datas = []
-        tss = []
-        for tt in dataset:
-            ts = self.fromTimestamp(tt.getStamp(), unixtime)
-            if datatype == 'MATRIXNUMERIC':
-                if isinstance(tt, spi.MatrixNumericDoubleData):
-                    val = np.array(tt.getMatrixDoubleValues(), dtype=float)
-                elif isinstance(tt, spi.MatrixNumericLongData):
-                    val = np.array(tt.getMatrixLongValues(), dtype=int)
-                else:
-                    self._log.warning('Unsupported datatype, returning the '
-                                      'java object')
-                    val = tt
-            elif datatype == 'VECTORNUMERIC':
-                if isinstance(tt, spi.VectorNumericDoubleData):
-                    val = np.array(tt.getDoubleValues()[:], dtype=float)
-                elif isinstance(tt, spi.VectorNumericLongData):
-                    val = np.array(tt.getLongValues()[:], dtype=int)
-                else:
-                    self._log.warning('Unsupported datatype, returning the '
-                                      'java object')
-                    val = tt
-            elif datatype == 'VECTORSTRING':
-                val = np.array(tt.getStringValues(), dtype='U')
-            elif datatype == 'NUMERIC':
-                if isinstance(tt, spi.NumericDoubleData):
-                    val = tt.getDoubleValue()
-                elif isinstance(tt, spi.NumericLongData):
-                    val = tt.getLongValue()
-                else:
-                    self._log.warning('Unsupported datatype, returning the '
-                                      'java object')
-                    val = tt
-            elif datatype == 'FUNDAMENTAL':
-                val = 1
-            elif datatype == 'TEXTUAL':
-                val = tt.getVarcharValue()
+        if type(dataset) is list:
+            new_ds = jpype.JPackage('cern').accsoft.cals.extr.domain.core.timeseriesdata.spi.TimeseriesDataSetImpl()
+            for data in dataset:
+                new_ds.add(data)
+            dataset = new_ds
+
+        if dataset.isEmpty():
+            return (np.array([], dtype=float), np.array([], dtype=float))
+
+        PrimitiveDataSets = jpype.JPackage('cern').lhc.commons.cals.PrimitiveDataSets
+        timestamps = np.array(PrimitiveDataSets.unixTimestamps(dataset)[:], dtype=float)
+        if not unixtime:
+            timestamps = np.array([datetime.datetime.fromtimestamp(t) for t in timestamps])
+
+        dataclass = PrimitiveDataSets.dataClass(dataset)
+        if datatype == 'MATRIXNUMERIC':
+            if dataclass == spi.MatrixNumericDoubleData:
+                data = np.array([[np.array(a[:], dtype=float) for a in matrix] for matrix in
+                                 PrimitiveDataSets.doubleMatrixData(dataset)])
+            elif dataclass == spi.MatrixNumericLongData:
+                data = np.array([[np.array(a[:], dtype=int) for a in matrix] for matrix in
+                                 PrimitiveDataSets.longMatrixData(dataset)])
             else:
                 self._log.warning('Unsupported datatype, returning the '
                                   'java object')
-                val = tt
-            datas.append(val)
-            tss.append(ts)
-        tss = np.array(tss)
-        datas = np.array(datas)
-        return (tss, datas)
+                data = [t for t in dataset]
+        elif datatype == 'VECTORNUMERIC':
+            if dataclass == spi.VectorNumericDoubleData:
+                data = np.array([np.array(a[:], dtype=float) for a in PrimitiveDataSets.doubleVectorData(dataset)])
+            elif dataclass == spi.VectorNumericLongData:
+                data = np.array([np.array(a[:], dtype=int) for a in PrimitiveDataSets.longVectorData(dataset)])
+            else:
+                self._log.warning('Unsupported datatype, returning the '
+                                  'java object')
+                data = [t for t in dataset]
+        elif datatype == 'VECTORSTRING':
+            data = np.array([np.array(a[:], dtype='U') for a in PrimitiveDataSets.stringVectorData(dataset)])
+        elif datatype == 'NUMERIC':
+            if dataclass == spi.NumericDoubleData:
+                data = np.array(PrimitiveDataSets.doubleData(dataset)[:], dtype=float)
+            elif dataclass == spi.NumericLongData:
+                data = np.array(PrimitiveDataSets.longData(dataset)[:], dtype=int)
+            else:
+                self._log.warning('Unsupported datatype, returning the '
+                                  'java object')
+                data = [t for t in dataset]
+        elif datatype == 'FUNDAMENTAL':
+            data = np.ones_like(timestamps, dtype=bool)
+        elif datatype == 'TEXTUAL':
+            data = np.array(PrimitiveDataSets.stringData(dataset)[:], dtype='U')
+        else:
+            self._log.warning('Unsupported datatype, returning the '
+                              'java object')
+            data = [t for t in dataset]
+        return (timestamps, data)
 
     def getAligned(self, pattern_or_list, t1, t2,
                    fundamental=None, master=None, unixtime=True):
@@ -323,7 +335,7 @@ class LoggingDB(object):
             self._log.info('Retrieved {0} values for {1}'.format(
                 res.size(), jvar.getVariableName()
             ))
-            self._log.info('{0} seconds for aqn'.format(time.time()-start_time))
+            self._log.info('{0} seconds for aqn'.format(time.time() - start_time))
             out[v] = self.processDataset(
                 res, res.getVariableDataType().toString(), unixtime
             )[1]
@@ -355,8 +367,8 @@ class LoggingDB(object):
             for v in variables:
                 logvars.append(v)
                 self._log.info('List of variables to be queried: {0}'.format(
-                ', '.join(logvars)
-            ))
+                    ', '.join(logvars)
+                ))
 
         # Acquire
         data = self._ts.getVariableStatisticsOverMultipleVariablesInTimeWindow(
@@ -381,24 +393,24 @@ class LoggingDB(object):
 
         return out
 
-#    def getSize(self, pattern_or_list, t1, t2):
-#        ts1 = self.toTimestamp(t1)
-#        ts2 = self.toTimestamp(t2)
-#
-#        # Build variable list
-#        variables = self.getVariablesList(pattern_or_list)
-#        if len(variables) == 0:
-#            log.warning('No variables found.')
-#            return {}
-#        else:
-#            logvars = []
-#            for v in variables:
-#                logvars.append(v)
-#            log.info('List of variables to be queried: {0}'.format(
-#                ', '.join(logvars)))
-#        # Acquire
-#        for v in variables:
-#            return self._ts.getJVMHeapSizeEstimationForDataInTimeWindow(v,ts1,ts2,None,None)
+    #    def getSize(self, pattern_or_list, t1, t2):
+    #        ts1 = self.toTimestamp(t1)
+    #        ts2 = self.toTimestamp(t2)
+    #
+    #        # Build variable list
+    #        variables = self.getVariablesList(pattern_or_list)
+    #        if len(variables) == 0:
+    #            log.warning('No variables found.')
+    #            return {}
+    #        else:
+    #            logvars = []
+    #            for v in variables:
+    #                logvars.append(v)
+    #            log.info('List of variables to be queried: {0}'.format(
+    #                ', '.join(logvars)))
+    #        # Acquire
+    #        for v in variables:
+    #            return self._ts.getJVMHeapSizeEstimationForDataInTimeWindow(v,ts1,ts2,None,None)
 
     def get(self, pattern_or_list, t1, t2=None,
             fundamental=None, unixtime=True):
@@ -456,7 +468,7 @@ class LoggingDB(object):
                 else:
                     datatype = res[0].getVariableDataType().toString()
                     self._log.info('Retrieved {0} values for {1}'.format(
-                       1, jvar.getVariableName()
+                        1, jvar.getVariableName()
                     ))
             elif t2 == 'next':
                 res = [
@@ -486,8 +498,8 @@ class LoggingDB(object):
             out[v] = self.processDataset(res, datatype, unixtime)
         return out
 
-    def getScaled(self, pattern_or_list, t1, t2,unixtime=True,
-            scaleAlgorithm='SUM', scaleInterval='MINUTE', scaleSize='1'):
+    def getScaled(self, pattern_or_list, t1, t2, unixtime=True,
+                  scaleAlgorithm='SUM', scaleInterval='MINUTE', scaleSize='1'):
         """Query the database for a list of variables or for variables whose
         name matches a pattern (string) in a time window from t1 to t2.
 
@@ -500,7 +512,7 @@ class LoggingDB(object):
         """
         ts1 = self.toTimestamp(t1)
         ts2 = self.toTimestamp(t2)
-        timescaling=self.toTimescale([scaleSize,scaleInterval,scaleAlgorithm])
+        timescaling = self.toTimescale([scaleSize, scaleInterval, scaleAlgorithm])
 
         out = {}
         # Build variable list
@@ -519,15 +531,15 @@ class LoggingDB(object):
         for v in variables:
             jvar = variables.getVariable(v)
             try:
-              res = self._ts.getDataInFixedIntervals(jvar, ts1, ts2, timescaling)
+                res = self._ts.getDataInFixedIntervals(jvar, ts1, ts2, timescaling)
             except jpype.JavaException as e:
-              print(e.message())
-              print('''
+                print(e.message())
+                print('''
                    scaleAlgorithm should be one of:{},
                    scaleInterval one of:{},
-                   scaleSize an integer'''.format(['MAX','MIN','AVG','COUNT','SUM','REPEAT','INTERPOLATE']
-                       ,['SECOND', 'MINUTE','HOUR', 'DAY','WEEK','MONTH','YEAR'])) 
-              return
+                   scaleSize an integer'''.format(['MAX', 'MIN', 'AVG', 'COUNT', 'SUM', 'REPEAT', 'INTERPOLATE']
+                                                  , ['SECOND', 'MINUTE', 'HOUR', 'DAY', 'WEEK', 'MONTH', 'YEAR']))
+                return
             datatype = res.getVariableDataType().toString()
             self._log.info('Retrieved {0} values for {1}'.format(
                 res.size(), jvar.getVariableName()
@@ -599,7 +611,7 @@ class LoggingDB(object):
 
             fills = (
                 self._FillService
-                .getLHCFillsAndBeamModesInTimeWindowContainingBeamModes(
+                    .getLHCFillsAndBeamModesInTimeWindowContainingBeamModes(
                     ts1, ts2, java_beam_modes
                 )
             )
@@ -625,32 +637,33 @@ class LoggingDB(object):
         """
         ts1 = self.toTimestamp(t1)
         ts2 = self.toTimestamp(t2)
-        fills=self.getLHCFillsByTime(ts1,ts2,[mode1,mode2])
-        out=[]
+        fills = self.getLHCFillsByTime(ts1, ts2, [mode1, mode2])
+        out = []
         for fill in fills:
-            fn=[fill['fillNumber']]
-            m1=[]
-            m2=[]
+            fn = [fill['fillNumber']]
+            m1 = []
+            m2 = []
             for bm in fill['beamModes']:
-                if bm['mode']==mode1:
-                   m1.append(bm[mode1time])
-                if bm['mode']==mode2:
-                   m2.append(bm[mode2time])
-            if len(m1)>0 and len(m2)>0:
-              out.append([fn,m1[mode1idx],m2[mode2idx]])
+                if bm['mode'] == mode1:
+                    m1.append(bm[mode1time])
+                if bm['mode'] == mode2:
+                    m2.append(bm[mode2time])
+            if len(m1) > 0 and len(m2) > 0:
+                out.append([fn, m1[mode1idx], m2[mode2idx]])
         return out
-    def getMetaData(self,pattern_or_list):
+
+    def getMetaData(self, pattern_or_list):
         """Get All MetaData for a variable defined by a pattern_or_list"""
-        out={}
+        out = {}
         variables = self.getVariablesList(pattern_or_list).getVariables()
         for variable in variables:
-            metadata=(self._md.getVectorElements(variable)
-                                 .getVectornumericElements())
-            ts=[tt.fastTime/1000+tt.getNanos()/1e9 for tt in  metadata]
-#            vv=[dict([(aa.key,aa.value) for aa in a.iterator()])
-#                    for a in metadata.values()]
-            vv=[[aa.value for aa in a.iterator()] for a in metadata.values()]
-            out[variable.getVariableName()]=ts,vv
+            metadata = (self._md.getVectorElements(variable)
+                        .getVectornumericElements())
+            ts = [tt.fastTime / 1000 + tt.getNanos() / 1e9 for tt in metadata]
+            #            vv=[dict([(aa.key,aa.value) for aa in a.iterator()])
+            #                    for a in metadata.values()]
+            vv = [[aa.value for aa in a.iterator()] for a in metadata.values()]
+            out[variable.getVariableName()] = ts, vv
         return out
 
 
@@ -674,7 +687,7 @@ class Hierarchy(object):
 
     def _cleanName(self, s):
         if s[0].isdigit():
-            s = '_'+s
+            s = '_' + s
         out = []
         for ss in s:
             if ss in ' _-;></:.':
@@ -694,7 +707,7 @@ class Hierarchy(object):
             return Hierarchy(k, self._dict[k], self.src, self.varsrc)
 
     def __dir__(self):
-        if jpype.isThreadAttachedToJVM()==0:
+        if jpype.isThreadAttachedToJVM() == 0:
             jpype.attachThreadToJVM()
         v = sorted([self._cleanName(i) for i in self._get_vars() if len(i) > 0])
         return sorted(self._dict.keys()) + v


### PR DESCRIPTION
Hi,

This is an experimental patch to improve the performance of processDataset(), in particular when it comes to large scalar data sets (few 100k points in time). In that case, 90+% of the time for get() is spent in processDataset() unpacking java objects ...
To overcome this limitation, I've added a dependency to a small java utils project (called lhc-commons-cals-utils - but it's not limited to LHC actually) which contains a class to transform the TimeseriesDataSets into primitive Java arrays. These can then be transferred to numpy counterparts by the slicing trick we already did for vectornumerics. See profiling results below.

I've tested this with my own scripts for various datatypes, but please test it in your use cases before merging - it's a fairly significant change...

Cheers,
Michi

Profiling without the patch:
```
cProfile.run("cals.get('LHC.BCTFR.A6R4.B1:BEAM_INTENSITY', '2017-08-30 00:00:00', '2017-09-06 00:00:00')")
         31447967 function calls (30843193 primitive calls) in 77.653 seconds

   Ordered by: standard name

   ncalls  tottime  percall  cumtime  percall filename:lineno(function)
        7    0.000    0.000    0.000    0.000 <frozen importlib._bootstrap>:989(_handle_fromlist)
        1    0.000    0.000   77.653   77.653 <string>:1(<module>)
        2    0.000    0.000    0.000    0.000 __init__.py:1291(info)
        2    0.000    0.000    0.000    0.000 __init__.py:1523(getEffectiveLevel)
        2    0.000    0.000    0.000    0.000 __init__.py:1537(isEnabledFor)
        7    0.000    0.000    0.000    0.000 _core.py:40(isJVMStarted)
        1    0.000    0.000    0.000    0.000 _jclass.py:165(<lambda>)
   604760    0.958    0.000    3.350    0.000 _jclass.py:171(<lambda>)
  1209545    1.663    0.000    2.689    0.000 _jclass.py:60(_getClassFor)
  1209538    2.835    0.000    3.701    0.000 _jclass.py:78(_javaInit)
10281007/9676247   12.596    0.000   18.987    0.000 _jclass.py:89(_javaGetAttr)
        1    0.000    0.000    0.000    0.000 _jcollection.py:188(_mapLength)
        2    0.000    0.000    0.000    0.000 _jcollection.py:191(_mapIter)
   604765   19.032    0.000   28.076    0.000 _jcollection.py:233(_iterCustomNext)
        3    0.000    0.000    0.000    0.000 _jcollection.py:25(__init__)
   604765    0.515    0.000   29.228    0.000 _jcollection.py:31(__next__)
        1    0.000    0.000    0.000    0.000 _jcollection.py:54(_colIter)
        6    0.000    0.000    0.000    0.000 _jexception.py:26(__init__)
        7    0.000    0.000    0.000    0.000 _jpackage.py:22(__init__)
    25/11    0.000    0.000    0.003    0.000 _jpackage.py:25(__getattribute__)
       14    0.000    0.000    0.000    0.000 _jpackage.py:49(__setattr__)
   604760    6.888    0.000   14.356    0.000 pytimber.py:112(fromTimestamp)
        1    0.012    0.012    0.016    0.016 pytimber.py:153(getVariablesList)
        1   21.021   21.021   73.932   73.932 pytimber.py:172(processDataset)
        1    3.705    3.705   77.653   77.653 pytimber.py:352(get)
        2    0.000    0.000    0.000    0.000 pytimber.py:94(toTimestamp)
        7    0.003    0.000    0.003    0.000 {built-in method _jpype.findClass}
        7    0.000    0.000    0.000    0.000 {built-in method _jpype.isStarted}
        1    0.000    0.000   77.653   77.653 {built-in method builtins.exec}
       14    0.000    0.000    0.000    0.000 {built-in method builtins.hasattr}
 11490554    4.344    0.000    4.344    0.000 {built-in method builtins.isinstance}
  1209553    0.453    0.000    0.453    0.000 {built-in method builtins.len}
   604765    0.636    0.000   28.712    0.000 {built-in method builtins.next}
        2    0.043    0.021    0.043    0.021 {built-in method numpy.core.multiarray.array}
  1209521    0.422    0.000    0.422    0.000 {method 'append' of 'list' objects}
        1    0.000    0.000    0.000    0.000 {method 'disable' of '_lsprof.Profiler' objects}
        9    0.000    0.000    0.000    0.000 {method 'format' of 'str' objects}
   604760    1.501    0.000    1.501    0.000 {method 'getInstanceAttribute' of 'JavaField' objects}
  1209545    1.025    0.000    1.025    0.000 {method 'getName' of 'JavaClass' objects}
        1    0.000    0.000    0.000    0.000 {method 'getStaticAttribute' of 'JavaField' objects}
        1    0.000    0.000    0.000    0.000 {method 'join' of 'str' objects}
```

Profiling with the patch (speedup of  10x-20x, CPU load also decreased significantly):
```
cProfile.run("cals.get('LHC.BCTFR.A6R4.B1:BEAM_INTENSITY', '2017-08-30 00:00:00', '2017-09-06 00:00:00')")
         1023 function calls (985 primitive calls) in 4.710 seconds

   Ordered by: standard name

   ncalls  tottime  percall  cumtime  percall filename:lineno(function)
       19    0.000    0.000    0.000    0.000 <frozen importlib._bootstrap>:996(_handle_fromlist)
        1    0.001    0.001    4.710    4.710 <string>:1(<module>)
        2    0.000    0.000    0.000    0.000 __init__.py:118(getLevelName)
        2    0.000    0.000    0.001    0.001 __init__.py:1269(info)
        2    0.000    0.000    0.000    0.000 __init__.py:1347(findCaller)
        2    0.000    0.000    0.000    0.000 __init__.py:1377(makeRecord)
        2    0.000    0.000    0.001    0.001 __init__.py:1392(_log)
        2    0.000    0.000    0.001    0.001 __init__.py:1417(handle)
        2    0.000    0.000    0.001    0.001 __init__.py:1471(callHandlers)
        2    0.000    0.000    0.000    0.000 __init__.py:149(<lambda>)
        2    0.000    0.000    0.000    0.000 __init__.py:1501(getEffectiveLevel)
        2    0.000    0.000    0.000    0.000 __init__.py:1515(isEnabledFor)
        2    0.000    0.000    0.000    0.000 __init__.py:243(__init__)
        2    0.000    0.000    0.000    0.000 __init__.py:321(getMessage)
        2    0.000    0.000    0.000    0.000 __init__.py:379(usesTime)
        2    0.000    0.000    0.000    0.000 __init__.py:382(format)
        2    0.000    0.000    0.000    0.000 __init__.py:487(formatTime)
        2    0.000    0.000    0.000    0.000 __init__.py:532(usesTime)
        2    0.000    0.000    0.000    0.000 __init__.py:538(formatMessage)
        2    0.000    0.000    0.000    0.000 __init__.py:554(format)
        4    0.000    0.000    0.000    0.000 __init__.py:695(filter)
        4    0.000    0.000    0.000    0.000 __init__.py:799(acquire)
        4    0.000    0.000    0.000    0.000 __init__.py:806(release)
        2    0.000    0.000    0.000    0.000 __init__.py:819(format)
        2    0.000    0.000    0.001    0.001 __init__.py:842(handle)
        2    0.000    0.000    0.001    0.000 __init__.py:957(flush)
        2    0.000    0.000    0.001    0.001 __init__.py:968(emit)
       19    0.000    0.000    0.000    0.000 _core.py:40(isJVMStarted)
        2    0.000    0.000    0.000    0.000 _jarray.py:140(_getClassFor)
        2    0.000    0.000    0.000    0.000 _jarray.py:42(__init__)
        2    0.000    0.000    0.000    0.000 _jarray.py:48(__len__)
        2    0.000    0.000    0.003    0.001 _jarray.py:54(__getitem__)
        2    0.000    0.000    0.003    0.001 _jarray.py:75(__getslice__)
        2    0.000    0.000    0.000    0.000 _jarray.py:85(_jarrayInit)
        1    0.000    0.000    0.000    0.000 _jclass.py:165(<lambda>)
       47    0.000    0.000    0.000    0.000 _jclass.py:60(_getClassFor)
       27    0.000    0.000    0.000    0.000 _jclass.py:78(_javaInit)
      109    0.000    0.000    0.000    0.000 _jclass.py:89(_javaGetAttr)
        1    0.000    0.000    0.000    0.000 _jcollection.py:188(_mapLength)
        2    0.000    0.000    0.000    0.000 _jcollection.py:191(_mapIter)
        4    0.000    0.000    0.000    0.000 _jcollection.py:233(_iterCustomNext)
        2    0.000    0.000    0.000    0.000 _jcollection.py:25(__init__)
        4    0.000    0.000    0.000    0.000 _jcollection.py:31(__next__)
       16    0.000    0.000    0.000    0.000 _jexception.py:26(__init__)
       19    0.000    0.000    0.000    0.000 _jpackage.py:22(__init__)
    61/23    0.000    0.000    0.017    0.001 _jpackage.py:25(__getattribute__)
       38    0.000    0.000    0.000    0.000 _jpackage.py:49(__setattr__)
        2    0.000    0.000    0.000    0.000 common.py:75(wake)
        2    0.000    0.000    0.000    0.000 genericpath.py:111(_splitext)
        6    0.000    0.000    0.000    0.000 ioloop.py:932(add_callback)
        4    0.000    0.000    0.000    0.000 iostream.py:228(_is_master_process)
        4    0.000    0.000    0.000    0.000 iostream.py:241(_schedule_flush)
        2    0.000    0.000    0.001    0.000 iostream.py:259(flush)
        4    0.000    0.000    0.000    0.000 iostream.py:309(write)
        2    0.000    0.000    0.000    0.000 ntpath.py:120(splitdrive)
        2    0.000    0.000    0.000    0.000 ntpath.py:197(split)
        2    0.000    0.000    0.000    0.000 ntpath.py:220(splitext)
        2    0.000    0.000    0.000    0.000 ntpath.py:230(basename)
        2    0.000    0.000    0.000    0.000 ntpath.py:35(_get_bothseps)
        2    0.000    0.000    0.000    0.000 ntpath.py:45(normcase)
        2    0.000    0.000    0.000    0.000 process.py:137(name)
        2    0.000    0.000    0.000    0.000 process.py:35(current_process)
        2    0.000    0.000    0.000    0.000 pytimber.py:103(toTimestamp)
        1    0.041    0.041    0.049    0.049 pytimber.py:183(getVariablesList)
        1    0.019    0.019    0.034    0.034 pytimber.py:202(processDataset)
        1    4.624    4.624    4.709    4.709 pytimber.py:415(get)
        6    0.000    0.000    0.000    0.000 stack_context.py:253(wrap)
        2    0.000    0.000    0.000    0.000 threading.py:1060(_wait_for_tstate_lock)
        2    0.000    0.000    0.000    0.000 threading.py:1074(name)
        2    0.000    0.000    0.000    0.000 threading.py:1102(is_alive)
        2    0.000    0.000    0.000    0.000 threading.py:1224(current_thread)
        2    0.000    0.000    0.000    0.000 threading.py:213(__init__)
        2    0.000    0.000    0.000    0.000 threading.py:237(__enter__)
        2    0.000    0.000    0.000    0.000 threading.py:240(__exit__)
        2    0.000    0.000    0.000    0.000 threading.py:246(_release_save)
        2    0.000    0.000    0.000    0.000 threading.py:249(_acquire_restore)
        2    0.000    0.000    0.000    0.000 threading.py:252(_is_owned)
        2    0.000    0.000    0.001    0.000 threading.py:261(wait)
        2    0.000    0.000    0.000    0.000 threading.py:496(__init__)
        2    0.000    0.000    0.000    0.000 threading.py:504(is_set)
        2    0.000    0.000    0.001    0.000 threading.py:531(wait)
       19    0.017    0.001    0.017    0.001 {built-in method _jpype.findClass}
        2    0.000    0.000    0.000    0.000 {built-in method _jpype.getArrayLength}
        2    0.003    0.001    0.003    0.001 {built-in method _jpype.getArraySlice}
       19    0.000    0.000    0.000    0.000 {built-in method _jpype.isStarted}
        4    0.000    0.000    0.000    0.000 {built-in method _thread.allocate_lock}
       10    0.000    0.000    0.000    0.000 {built-in method _thread.get_ident}
        1    0.000    0.000    4.710    4.710 {built-in method builtins.exec}
       50    0.000    0.000    0.000    0.000 {built-in method builtins.hasattr}
      169    0.000    0.000    0.000    0.000 {built-in method builtins.isinstance}
       74    0.000    0.000    0.000    0.000 {built-in method builtins.len}
        2    0.000    0.000    0.000    0.000 {built-in method builtins.max}
        4    0.000    0.000    0.000    0.000 {built-in method builtins.next}
        6    0.000    0.000    0.000    0.000 {built-in method nt.getpid}
        2    0.003    0.002    0.003    0.002 {built-in method numpy.core.multiarray.array}
        2    0.000    0.000    0.000    0.000 {built-in method sys._getframe}
        2    0.000    0.000    0.000    0.000 {built-in method time.localtime}
        2    0.000    0.000    0.000    0.000 {built-in method time.strftime}
        2    0.000    0.000    0.000    0.000 {built-in method time.time}
        2    0.000    0.000    0.000    0.000 {method '__enter__' of '_thread.lock' objects}
        2    0.000    0.000    0.000    0.000 {method '__exit__' of '_thread.lock' objects}
        4    0.000    0.000    0.000    0.000 {method 'acquire' of '_thread.RLock' objects}
       10    0.001    0.000    0.001    0.000 {method 'acquire' of '_thread.lock' objects}
        2    0.000    0.000    0.000    0.000 {method 'append' of 'collections.deque' objects}
        7    0.000    0.000    0.000    0.000 {method 'append' of 'list' objects}
        1    0.000    0.000    0.000    0.000 {method 'disable' of '_lsprof.Profiler' objects}
        2    0.000    0.000    0.000    0.000 {method 'find' of 'str' objects}
       21    0.000    0.000    0.000    0.000 {method 'format' of 'str' objects}
        6    0.000    0.000    0.000    0.000 {method 'get' of 'dict' objects}
       47    0.000    0.000    0.000    0.000 {method 'getName' of 'JavaClass' objects}
        1    0.000    0.000    0.000    0.000 {method 'getStaticAttribute' of 'JavaField' objects}
        2    0.000    0.000    0.000    0.000 {method 'indices' of 'slice' objects}
        1    0.000    0.000    0.000    0.000 {method 'join' of 'str' objects}
        2    0.000    0.000    0.000    0.000 {method 'lower' of 'str' objects}
        4    0.000    0.000    0.000    0.000 {method 'release' of '_thread.RLock' objects}
        2    0.000    0.000    0.000    0.000 {method 'release' of '_thread.lock' objects}
        4    0.000    0.000    0.000    0.000 {method 'replace' of 'str' objects}
        6    0.000    0.000    0.000    0.000 {method 'rfind' of 'str' objects}
        2    0.000    0.000    0.000    0.000 {method 'rstrip' of 'str' objects}
        2    0.000    0.000    0.000    0.000 {method 'send' of '_socket.socket' objects}
        4    0.000    0.000    0.000    0.000 {method 'write' of '_io.StringIO' objects}
```