### PR TITLE
Add a pyproject.toml to document the setup.py dependencies

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,0 +1,2 @@
+[build-system]
+requires = ["setuptools", "cmmnbuild-dep-manager"]


### PR DESCRIPTION
This will ensure that ``cmmnbuild-dep-manager`` is installed *before* ``setup.py`` is run.

Ref: https://www.python.org/dev/peps/pep-0518/#rationale